### PR TITLE
デプロイ先のURLを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# アプリ"Task Cabinet"
+# アプリ "Task Cabinet"
 
 ## エレベーターピッチ
 今、自分が何をすべきかを手が空いた時に通知してくれるタスク管理ツール「Task Cabinet」
@@ -10,42 +10,44 @@ CS1年
 高橋, 畑中, 松本, 江畑, 小坂, 高木
 
 ## デプロイ先URL
-https://enpitut2019.github.io/task-cabinet/
+https://task-cabinet.herokuapp.com/
 
-## Project setup
+## Development
+
+### Project setup
 ```
 yarn install
 ```
 
-### Compiles and hot-reloads for development
+#### Compiles and hot-reloads for development
 ```
 yarn run serve
 ```
 
-### Compiles and minifies for production
+#### Compiles and minifies for production
 ```
 yarn run build
 ```
 
-### Run your tests
+#### Run your tests
 ```
 yarn run test
 ```
 
-### Lints and fixes files
+#### Lints and fixes files
 ```
 yarn run lint
 ```
 
-### Run your end-to-end tests
+#### Run your end-to-end tests
 ```
 yarn run test:e2e
 ```
 
-### Run your unit tests
+#### Run your unit tests
 ```
 yarn run test:unit
 ```
 
-### Customize configuration
+#### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).


### PR DESCRIPTION
README.md 内の URL が古いままだったので更新しました。また、最初からあった開発用のコマンドリストは Development セクションに移動しました。