### PR TITLE
タスク追加時の期限初期値をJSTの現在時刻に設定

### DIFF
--- a/src/views/TodoAdd.vue
+++ b/src/views/TodoAdd.vue
@@ -41,7 +41,7 @@
           </v-date-picker>
         </v-menu>
       </v-flex>
-      <!--日付の選択-->
+      <!--時刻の選択-->
       <v-flex xs12 sm12>
         <v-layout column :align-center="true">
           <v-time-picker
@@ -74,10 +74,12 @@ export default {
     },
   },
   data() {
+    let jst = new Date();
+    jst.setTime(jst.getTime()+1000*60*60*9);
     return {
       name: '',
-      date: new Date().toISOString().substr(0, 10),
-      time: null,
+      date: jst.toISOString().substr(0, 10),
+      time: jst.toISOString().substr(11, 5),
       menu: false,
       modal: false,
     };


### PR DESCRIPTION
・「時刻の選択」コメントが「日付の選択」になっていたのを修正
・new Date()はUTCが返るので, 9時間足してJSTに修正

jst.toISOString().substr(11, 5) は hh:mm を返す