### PR TITLE
クリックするまで通知が消えないようにする (macOS など)

### DIFF
--- a/src/views/Todo.vue
+++ b/src/views/Todo.vue
@@ -122,6 +122,7 @@ export default {
 
       push.create(todo.name, {
         body: todo.deadline.format('YYYY-MM-DD HH:mm'),
+        requireInteraction: true,
         onClick: () => {
           window.focus();
           this.close();


### PR DESCRIPTION
macOSなどでは、通知が5秒で消えてしまうため、表示後すぐに読まないとタスクを見逃してしまう問題がありました。この変更で通知が勝手に消えないようになり、確実に確認ができるようになります。