### PR TITLE
クリックするまで通知が消えないようにする

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -61,6 +61,7 @@ const pushNotification = async (time, message) => {
         console.log(`pushNotification time:${time} message:${message}`);
         if (pushTodo) {
             self.registration.showNotification(pushTodo.name, {
+                requireInteraction: true,
                 body: unixTime2ymd(pushTodo.deadline)
             });
         }


### PR DESCRIPTION
#35 の反映
>> macOSなどでは、通知が5秒で消えてしまうため、表示後すぐに読まないとタスクを見逃してしまう問題がありました。この変更で通知が勝手に消えないようになり、確実に確認ができるようになります。